### PR TITLE
Using nugetrestore before running msbuild

### DIFF
--- a/Build/gruntfile.js
+++ b/Build/gruntfile.js
@@ -128,6 +128,12 @@ module.exports = function (grunt) {
             dist: {
                 src: 'dist/*.nupkg'
             }
+        },
+        nugetrestore: {
+            restore: {
+                src: '../src/**/packages.config',
+                dest: '../src/packages/'
+            }
         }
     });
     grunt.loadNpmTasks('grunt-nuget');
@@ -135,7 +141,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-dotnet-assembly-info');
- 
-    grunt.registerTask("default", ["clean", "assemblyinfo", "msbuild", "copy", "nugetpack"]);
+    grunt.registerTask("build", ["nugetrestore", "msbuild"])
+    grunt.registerTask("default", ["clean", "assemblyinfo", "build", "copy", "nugetpack"]);
     grunt.registerTask("push", ["default", "nugetpush"]);
 };


### PR DESCRIPTION
Using nugetrestore before running msbuild task. 

It should be possible to run the default grunt task on appveyor (and on travis later on).
