### PR TITLE
Fix typo: againt -> against

### DIFF
--- a/Src/Veil.Handlebars/HandlebarsExpressionParser.cs
+++ b/Src/Veil.Handlebars/HandlebarsExpressionParser.cs
@@ -54,7 +54,7 @@ namespace Veil.Handlebars
 
             if (IsLateBoundAcceptingType(modelType)) return SyntaxTreeExpression.LateBound(expression, false, expressionScope);
 
-            throw new VeilParserException(String.Format("Unable to parse model expression '{0}' againt model '{1}'", expression, modelType.Name));
+            throw new VeilParserException(String.Format("Unable to parse model expression '{0}' against model '{1}'", expression, modelType.Name));
         }
 
         private static MemberInfo FindMember(Type t, string name, MemberTypes types)


### PR DESCRIPTION
This fixes a minor typo in the property-lookup error message for Handlebars syntax.